### PR TITLE
feat: add private ai key token client method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -85,6 +85,24 @@ class Client
         return $this->post('/private-ai-keys', $data);
     }
 
+    public function createPrivateAIKeyToken(int $regionId, string $name, int $userId = 0, int $teamId = 0): array
+    {
+        $data = [
+            'region_id' => $regionId,
+            'name' => $name,
+        ];
+
+        if ($userId > 0) {
+            $data['owner_id'] = $userId;
+        }
+
+        if ($teamId > 0) {
+            $data['team_id'] = $teamId;
+        }
+
+        return $this->post('/private-ai-keys/token', $data);
+    }
+
     public function listPrivateAIKeys(): array
     {
         return $this->get('/private-ai-keys');


### PR DESCRIPTION
## Summary
- add `Client::createPrivateAIKeyToken()` to call `POST /private-ai-keys/token`
- accept `region_id`, `name`, and optional `owner_id` / `team_id` payload values
- keep existing `createPrivateAIKeys()` behavior unchanged for backwards compatibility

## Test plan
- [x] Confirm method composes payload correctly for `region_id` and `name`
- [x] Confirm optional `owner_id` is included only when > 0
- [x] Confirm optional `team_id` is included only when > 0
- [ ] Validate endpoint call in downstream app after `0.0.7` release

Made with [Cursor](https://cursor.com)