### PR TITLE
Configure AppSec in CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"
+- package-ecosystem: composer
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    composer:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"

--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -1,0 +1,24 @@
+# https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md
+allow-licenses:
+# default allowed
+- 'Apache-2.0'
+# explicit CNCF allowlist
+- '0BSD'
+- 'BSD-2-Clause'
+- 'BSD-2-Clause-FreeBSD'
+- 'BSD-3-Clause'
+- 'ISC'
+- 'MIT'
+- 'MIT-0'
+- 'OpenSSL'
+- 'OpenSSL-standalone'
+- 'PSF-2.0'
+- 'PostgreSQL'
+- 'Python-2.0'
+- 'Python-2.0.1'
+- 'SSLeay-standalone'
+- 'UPL-1.0'
+- 'X11'
+- 'Zlib'
+# Google's patent licence for Go
+- 'LicenseRef-scancode-google-patent-license-golang'

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,19 @@
+name: dependency review
+on:
+  pull_request:
+    branches:
+    - main
+  merge_group:
+    types:
+    - checks_requested
+permissions: {}
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      with:
+        config-file: .github/dependency-review-config.yaml


### PR DESCRIPTION
Partially fixes #1. The rest of the config changes required can be added when this is merged.

Closes #2.